### PR TITLE
Changing diretories format on yaml config

### DIFF
--- a/files/config/project_config.yaml
+++ b/files/config/project_config.yaml
@@ -1,5 +1,5 @@
-DATA_PATH: ..\data
-DATA_OUTPUT: ..\data\out
+DATA_PATH: ["..","data"]
+DATA_OUTPUT: ["..", "data", "out"]
 
 HOST : 'localhost'
 PORT : 2000


### PR DESCRIPTION
This fix enables the usage of the function os.path.join()